### PR TITLE
Return value itself that holds the data on POST requests

### DIFF
--- a/django_quill/forms.py
+++ b/django_quill/forms.py
@@ -19,6 +19,7 @@ class QuillFormJSONField(forms.JSONField):
     def prepare_value(self, value):
         if hasattr(value, "data"):
             return value.data
+        return value
 
     def has_changed(self, initial, data):
         if hasattr(initial, 'data'):


### PR DESCRIPTION
The issue is when there is a form error, QuillFormJSONField shows empty value even if the field has data. If the users does not realize that, they erase data without even knowing it.

